### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0](https://github.com/arcuru/headjack/compare/v0.4.0...v0.5.0) - 2024-10-25
+
+### Added
+
+- add key-value pair getter for room tags
+- adding tag helpers
+- [**breaking**] callback with the full message event
+
+### Other
+
+- install release-plz
+- adding Codeberg sync
+- add FUNDING.yml
+
 ## [0.4.0] - 2024-05-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "headjack"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headjack"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Patrick Jackson <patrick@jackson.dev>"]
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `headjack`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/arcuru/headjack/compare/v0.4.0...v0.5.0) - 2024-10-25

### Added

- add key-value pair getter for room tags
- adding tag helpers
- [**breaking**] callback with the full message event

### Other

- install release-plz
- adding Codeberg sync
- add FUNDING.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).